### PR TITLE
Prevent removeChild exception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export default function fragment(node) {
     node.content = document.createDocumentFragment();
 
     for (let i in children) {
-      node.content.appendChild(children[i]);
+      node.content.appendChild(document.adoptNode(children[i]));
     }
   }
 
@@ -28,7 +28,7 @@ export default function fragment(node) {
     destroy() {
       // Node content fragment doesnt longer have the references to the children
       // so its content need to be removed reference by reference
-      requestAnimationFrame(function() {
+      requestAnimationFrame(function () {
         for (let i in children) {
           if (parent && parent.contains(children[i])) {
             parent.removeChild(children[i]);

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,3 @@
 export default function fragment(node) {
-  node.parentElement.appendChild(node.content);
-  node.setAttribute('style', 'display: none;');
-
-  return {
-    destroy() {
-      if (
-        node &&
-        node.parentElement &&
-        node.parentNode.contains(node.content)
-      ) {
-        node.parentElement.removeChild(node.content);
-      }
-    },
-  };
+  node.parentElement.appendChild(document.adoptNode(node).content);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,21 @@ export default function fragment(node) {
 
   // As appening a fragment as node child remove its content, we need to save the
   // children references
-  const children = Array.prototype.slice.call(node.content.childNodes);
+  const children = Array.prototype.slice.call(
+    (node.content || node).childNodes,
+  );
 
+  // As the given node could not be a template tag we need to create a fragment
+  // for non template node
+  if (!node.content || node.content.nodeType !== 11) {
+    node.content = document.createDocumentFragment();
+
+    for (let i in children) {
+      node.content.appendChild(children[i]);
+    }
+  }
+
+  // By appending a fragment, its content will be spread inside the parrent
   parent.appendChild(node.content);
 
   // Svelte except an used node to have parent, so a fragment should adopt the node

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@ export default function fragment(node) {
 
   return {
     destroy() {
-      if (node && node.parentElement) {
+      if (
+        node &&
+        node.parentElement &&
+        node.parentNode.contains(node.content)
+      ) {
         node.parentElement.removeChild(node.content);
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,27 @@
 export default function fragment(node) {
-  node.parentElement.appendChild(document.adoptNode(node).content);
+  // We need to keep the reference of the parent because of the adoption
+  const parent = node.parentElement;
+
+  // As appening a fragment as node child remove its content, we need to save the
+  // children references
+  const children = Array.prototype.slice.call(node.content.childNodes);
+
+  parent.appendChild(node.content);
+
+  // Svelte except an used node to have parent, so a fragment should adopt the node
+  document.createDocumentFragment().appendChild(document.adoptNode(node));
+
+  return {
+    destroy() {
+      // Node content fragment doesnt longer have the references to the children
+      // so its content need to be removed reference by reference
+      requestAnimationFrame(function() {
+        for (let i in children) {
+          if (parent && parent.contains(children[i])) {
+            parent.removeChild(children[i]);
+          }
+        }
+      });
+    },
+  };
 }


### PR DESCRIPTION
This fix the 
```
 DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```
exception occuring when changing route using Sapper.

This occur because of the deletetion of the node in the DOM before of the `destroy` lifecycle being called.

fix #1 